### PR TITLE
Use the same branch as cucumber-ruby-meta for sub-repos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,16 @@ commands:
           command: |
             node_modules/meta/bin/meta git update
 
+  use_same_branch:
+    description: "Use same branch on all sub-repos"
+    steps:
+      - run:
+          name: "use correct branch on all sub-repos"
+          command:
+            git_branch=$(git symbolic-ref HEAD 2>/dev/null | cut -d"/" -f 3)
+            node_modules/meta/bin/meta git checkout $git_branch
+            node_modules/meta/bin/meta git pull
+
   test:
     description: "Run test on all sub-repos"
     steps:
@@ -50,6 +60,7 @@ jobs:
       - install_npm
       - install_meta
       - clone_sub_repos
+      - use_same_branch
       - test
 
   ruby-25:
@@ -61,6 +72,7 @@ jobs:
       - install_npm
       - install_meta
       - clone_sub_repos
+      - use_same_branch
       - test
 
   ruby-24:
@@ -72,6 +84,7 @@ jobs:
       - install_npm
       - install_meta
       - clone_sub_repos
+      - use_same_branch
       - test
 
   ruby-23:
@@ -83,6 +96,7 @@ jobs:
       - install_npm
       - install_meta
       - clone_sub_repos
+      - use_same_branch
       - test
 
 


### PR DESCRIPTION
This is a try mainly, but the idea is to be able to get the CI running on all sub-packages on the same branch (as we locally do).

This may cause more harm than good, for example when making PR specifically for this repo without code updated in sub-repos, or when the branch is only available on some of the sub-repos but not all of them.

Maybe some flags could help, I need to dig a bit more.